### PR TITLE
Include .ios extension in import

### DIFF
--- a/Zoomable.ios.js
+++ b/Zoomable.ios.js
@@ -107,6 +107,8 @@ class Zoomable extends React.Component {
         showsVerticalScrollIndicator={false}
         maximumZoomScale={this.props.zoomScale}
         centerContent
+        style={this.props.style}
+        contentContainerStyle={this.props.contentContainerStyle}
       >
         {this.props.children}
       </ScrollView>
@@ -120,6 +122,8 @@ Zoomable.propTypes = {
   zoomScale: PropTypes.number,
   zoomInTrigger: PropTypes.oneOf(['singletap', 'doubletap', 'longpress']),
   zoomOutTrigger: PropTypes.oneOf(['singletap', 'doubletap', 'longpress']),
+  style: PropTypes.shape({}),
+  contentContainerStyle: PropTypes.shape({}),
 };
 
 Zoomable.defaultProps = {
@@ -127,6 +131,8 @@ Zoomable.defaultProps = {
   zoomScale: 4,
   zoomInTrigger: 'doubletap',
   zoomOutTrigger: 'singletap',
+  style: {},
+  contentContainerStyle: {},
 };
 
 export default Zoomable;

--- a/index.js
+++ b/index.js
@@ -1,3 +1,3 @@
-import Zoomable from "./Zoomable.ios";
+import Zoomable from './Zoomable.ios';
 
 export default Zoomable;

--- a/index.js
+++ b/index.js
@@ -1,3 +1,3 @@
-import Zoomable from './Zoomable';
+import Zoomable from "./Zoomable.ios";
 
 export default Zoomable;


### PR DESCRIPTION
This PR aims to fix an issue experienced when trying to publish with Expo. When trying to publish the project Expo errors with `Unable to resolve module './Zoomable' from ... it did not contain a package, nor an index file`